### PR TITLE
fix: include error messages on shiny

### DIFF
--- a/R/rict-validate.R
+++ b/R/rict-validate.R
@@ -606,9 +606,12 @@ These values will be used instead of calculating them from Grid Reference values
   # Subset the 'passing' instances to run in prediction by removing "this_failing"
   data <- data[!data$SITE %in% this_failing$SITE, ] # Note, can't use dplyr::anti_join() in ML AZURE
   if (nrow(data) == 0 && stop_if_all_fail == TRUE) {
-    stop("You provided data that has failure(s) on every row.
+    stop(paste(list("You provided data that has failure(s) on every row.
        We expect at least one row without any fails to proceed.
-       HINT: Check fail messages, fix errors and re-try.", call. = FALSE)
+       HINT: Check fail messages, fix errors and re-try: ",
+                    paste(capture.output(print(checks)),
+              collapse = "\n")), collapse = "\n"),
+         call. = FALSE)
   }
 
   if (row == FALSE) {

--- a/inst/shiny_apps/rictapp/app.R
+++ b/inst/shiny_apps/rictapp/app.R
@@ -128,7 +128,8 @@ server <- function(input, output) {
     on.exit(progress$close())
     progress$set(message = "Calculating", value = 1)
     data <- read.csv(inFile$datapath, check.names = FALSE)
-    validations <- rict_validate(data)
+    options(shiny.sanitize.errors = FALSE)
+    validations <- rict_validate(data, stop_if_all_fail = FALSE)
     predictions <- rict_predict(data)
     predictions_table <- predictions
     # don't need to display all columns - some columns only used by some models


### PR DESCRIPTION
Expand detail in error message when all rows fail