### PR TITLE
fix: wip - print path to zip library

### DIFF
--- a/inst/shiny_apps/rictapp/app.R
+++ b/inst/shiny_apps/rictapp/app.R
@@ -456,6 +456,7 @@ server <- function(input, output) {
         fs <- c()
         tmpdir <- tempdir()
         setwd(tempdir())
+        message(system("which zip"))
         for (i in seq_along(output_files)) {
             path <- paste0(names(output_files)[i], ".csv")
             fs <- c(fs, path)


### PR DESCRIPTION
Shiny server can't find path to zip library, check print where zip library path in logs.